### PR TITLE
Clear transaction operations after run

### DIFF
--- a/snakeskin/models/gateway.py
+++ b/snakeskin/models/gateway.py
@@ -325,6 +325,8 @@ class GatewayTXBuilder:
             for operation in self._operations:
                 await operation()
 
+            self._operations.clear()
+
             if self._endorsed_tx:
                 return self._endorsed_tx
 


### PR DESCRIPTION
Clear transaction operations after they're run to allow running transaction steps individually